### PR TITLE
PR - Server: Feature water

### DIFF
--- a/client/game_display/ui_elements/game_worm_animation_set.cpp
+++ b/client/game_display/ui_elements/game_worm_animation_set.cpp
@@ -23,7 +23,8 @@ WormAnimationSet::WormAnimationSet(
 { MovementStateDto::IDLE          , idle },
 { MovementStateDto::MOVING        , moving },
 { MovementStateDto::GOING_UPWARDS , going_upwards },
-{ MovementStateDto::FALLING       , falling }
+{ MovementStateDto::FALLING       , falling },
+{ MovementStateDto::SINKING       , falling } // TODO for now same as falling
     }),
     aiming_idle_sprite({
 { WeaponTypeDto::BAZOOKA       , aiming_bazooka },

--- a/client/game_managment/client_receiver.cpp
+++ b/client/game_managment/client_receiver.cpp
@@ -33,6 +33,7 @@ void ClientReceiver::run(NetMessageInitialGameState* msg) {
 
     game_state_dto->width = msg->room_width;
     game_state_dto->height = msg->room_height;
+    game_state_dto->water_level_height = msg->water_height_level;
 
     std::cout << "w: " << msg->room_width << " - h: " << msg->room_height << '\n';
     std::cout << "worms in game " << msg->worms.size() << '\n';

--- a/client/game_ui/client_game_state.cpp
+++ b/client/game_ui/client_game_state.cpp
@@ -12,6 +12,7 @@ void ClientGameState::load(const std::shared_ptr<ClientGameStateDTO> &game_state
     std::cout << "Loading scenario size("
               << game_state_dto->width << ","
               << game_state_dto->height << ")"
+              << "   Water level: " << game_state_dto->water_level_height
               << "   Beams: " << game_state_dto->beams.size()
               << "   Worms: " << game_state_dto->worms.size() << "\n";
 

--- a/client/game_ui/client_game_state_dto.h
+++ b/client/game_ui/client_game_state_dto.h
@@ -14,6 +14,7 @@ public:
 
     float width;
     float height;
+    float water_level_height;
 
     int active_client_id;
     int active_entity_id;

--- a/common_base/Networking/Messages/net_message_initial_game_state.cpp
+++ b/common_base/Networking/Messages/net_message_initial_game_state.cpp
@@ -1,24 +1,24 @@
 #include "net_message_initial_game_state.h"
 
 NetMessageInitialGameState::NetMessageInitialGameState()
-    : NetMessage(NET_MESSAGE_TYPE_INITIAL_STATE)
-    {}
+    : NetMessage(NET_MESSAGE_TYPE_INITIAL_STATE) {}
 
-NetMessageInitialGameState::NetMessageInitialGameState(float room_width, float room_height)
-        : NetMessage(NET_MESSAGE_TYPE_INITIAL_STATE),
-        room_width(room_width),
-        room_height(room_height),
-        beams(),
-        worms()
-{}
+NetMessageInitialGameState::NetMessageInitialGameState(float room_width, float room_height, float water_height_level)
+    : NetMessage(NET_MESSAGE_TYPE_INITIAL_STATE),
+      room_width(room_width),
+      room_height(room_height),
+      water_height_level(water_height_level),
+      beams(),
+      worms() {}
 
-void NetMessageInitialGameState::push_data_into(NetBuffer& container) {
+void NetMessageInitialGameState::push_data_into(NetBuffer &container) {
     NetMessage::push_data_into(container);
     container.push_float(room_width);
     container.push_float(room_height);
+    container.push_float(water_height_level);
 
     container.push_short(beams.size());
-    for(auto& it : beams) {
+    for (auto &it: beams) {
         container.push_float(it.x);
         container.push_float(it.y);
         container.push_float(it.angle);
@@ -26,7 +26,7 @@ void NetMessageInitialGameState::push_data_into(NetBuffer& container) {
     }
 
     container.push_short(worms.size());
-    for(auto& it : worms) {
+    for (auto &it: worms) {
         container.push_uint(it.client_id);
         container.push_uint(it.entity_id);
         container.push_float(it.x);
@@ -40,38 +40,39 @@ void NetMessageInitialGameState::push_data_into(NetBuffer& container) {
     }
 }
 
-void NetMessageInitialGameState::pull_data_from(NetProtocolInterpreter& channel) {
+void NetMessageInitialGameState::pull_data_from(NetProtocolInterpreter &channel) {
     room_width = channel.read_float();
     room_height = channel.read_float();
+    water_height_level = channel.read_float();
 
     short beam_size = channel.read_short();
-    for(short i = 0; i < beam_size; i++) {
-        auto x     = channel.read_float();
-        auto y     = channel.read_float();
+    for (short i = 0; i < beam_size; i++) {
+        auto x = channel.read_float();
+        auto y = channel.read_float();
         auto angle = channel.read_float();
-        auto type  = static_cast<BeamDto::Type>(channel.read_byte());
+        auto type = static_cast<BeamDto::Type>(channel.read_byte());
 
         beams.emplace_back(x, y, angle, type);
     }
 
     short worms_size = channel.read_short();
-    for(int i = 0; i < worms_size; i++) {
+    for (int i = 0; i < worms_size; i++) {
         auto client_id = channel.read_uint();
         auto entity_id = channel.read_uint();
-        auto x         = channel.read_float();
-        auto y         = channel.read_float();
-        auto angle     = channel.read_float();
+        auto x = channel.read_float();
+        auto y = channel.read_float();
+        auto angle = channel.read_float();
         auto is_facing_right = channel.read_bool();
-        auto life      = channel.read_uint();
-        auto state     = static_cast<MovementStateDto>(channel.read_byte());
-        auto weapon_hold     = static_cast<WeaponTypeDto>(channel.read_byte());
-        auto aiming_angle     = channel.read_float();
+        auto life = channel.read_uint();
+        auto state = static_cast<MovementStateDto>(channel.read_byte());
+        auto weapon_hold = static_cast<WeaponTypeDto>(channel.read_byte());
+        auto aiming_angle = channel.read_float();
 
-        worms.emplace_back(client_id, entity_id, x, y, angle, is_facing_right,life, state, weapon_hold, aiming_angle);
+        worms.emplace_back(client_id, entity_id, x, y, angle, is_facing_right, life, state, weapon_hold, aiming_angle);
     }
 }
 
-void NetMessageInitialGameState::add(const BeamDto& beam) {
+void NetMessageInitialGameState::add(const BeamDto &beam) {
     beams.emplace_back(beam.x, beam.y, beam.angle, beam.type);
 }
 
@@ -79,6 +80,6 @@ void NetMessageInitialGameState::add(const WormDto &worm) {
     worms.push_back(worm);
 }
 
-void NetMessageInitialGameState::execute(NetMessageBehaviour& interpreter) {
+void NetMessageInitialGameState::execute(NetMessageBehaviour &interpreter) {
     interpreter.run(this);
 }

--- a/common_base/Networking/Messages/net_message_initial_game_state.h
+++ b/common_base/Networking/Messages/net_message_initial_game_state.h
@@ -10,11 +10,12 @@ class NetMessageInitialGameState : public NetMessage {
 public:
     float room_width;
     float room_height;
+    float water_height_level;
     std::vector<BeamDto> beams;
     std::vector<WormDto> worms;
     
     NetMessageInitialGameState();
-    NetMessageInitialGameState(float room_width, float room_height);
+    NetMessageInitialGameState(float room_width, float room_height, float water_height_level);
     ~NetMessageInitialGameState() override {};
 
     void add(const BeamDto& beam);

--- a/common_base/constants.h
+++ b/common_base/constants.h
@@ -20,6 +20,6 @@ const float PROJECTILE_RADIUS = 0.3f;
 const float SHOOT_POTENCY = 1;
 const float SHOT_OFFSET_FROM_WORM = (WORM_SIZE / 2) + PROJECTILE_RADIUS * 2;
 
-const float WATER_HEIGHT = 10;
+const float WATER_HEIGHT = 4;
 
 #endif

--- a/server/src/game/control/GameEngineInstance.cpp
+++ b/server/src/game/control/GameEngineInstance.cpp
@@ -77,7 +77,8 @@ void GameEngineInstance::initial_broadcast(const GameScenarioData &scenario) {
 void GameEngineInstance::_broadcast_initial_game_state(const GameScenarioData &scenario) {
     auto message = new NetMessageInitialGameState(
         scenario.room_width,
-        scenario.room_height
+        scenario.room_height,
+        scenario.water_height_level
     );
 
     for (auto item: scenario.beams) {

--- a/server/src/game/control/GameInstance.cpp
+++ b/server/src/game/control/GameInstance.cpp
@@ -12,7 +12,7 @@ GameInstance::GameInstance(
     instances_manager(physics_system, scenarioData),
     clientsWorms(),
     turn_system(rate),
-    updatables_system(),
+    updatables_system(rate),
     shot_system(instances_manager) {
 
     assign_worms_to_clients(clients);

--- a/server/src/game/control/GameNetMessageBehaviour.cpp
+++ b/server/src/game/control/GameNetMessageBehaviour.cpp
@@ -95,7 +95,6 @@ void GameNetMessageBehaviour::run(NetMessageGameAction *msg) {
 
 
 void GameNetMessageBehaviour::run(NetMessagePlayerChangedWeapon *msg) {
-    std::cout << "NetMessageBehaviour received the change weapon call\n";
     if (!game.is_client_turn(msg->client_id)) {
         return;
     }

--- a/server/src/game/model/core/Updatable.h
+++ b/server/src/game/model/core/Updatable.h
@@ -3,7 +3,7 @@
 
 class Updatable {
 public:
-    virtual void update(int it) = 0;
+    virtual void update(int it, int rate) = 0;
 };
 
 #endif //TP_WORMS_UPDATABLE_H

--- a/server/src/game/model/projectiles/Projectile.cpp
+++ b/server/src/game/model/projectiles/Projectile.cpp
@@ -20,7 +20,7 @@ ProjectileDto Projectile::to_dto() const {
     );
 }
 
-void Projectile::update(const int it) {
+void Projectile::update(const int it, const int rate) {
     body->on_update();
 }
 

--- a/server/src/game/model/projectiles/Projectile.cpp
+++ b/server/src/game/model/projectiles/Projectile.cpp
@@ -6,6 +6,8 @@ Projectile::Projectile(size_t id, const std::unique_ptr<ProjectileInfo> &info) :
     Instance(id),
     weapon_type(info->from_weapon),
     exploded(false),
+    is_on_water(false),
+    on_water_time_life(2000),
     damage(info->damage),
     explosion_radius(info->explosion_radius),
     body(nullptr)
@@ -21,6 +23,13 @@ ProjectileDto Projectile::to_dto() const {
 }
 
 void Projectile::update(const int it, const int rate) {
+    if (is_on_water) {
+        on_water_time_life -= it * rate;
+        if (on_water_time_life <= 0) {
+            is_active = false;
+            return;
+        }
+    }
     body->on_update();
 }
 
@@ -42,6 +51,7 @@ b2Body* Projectile::B2Body() {
 }
 
 void Projectile::sink() {
+    is_on_water = true;
     body->sink();
 }
 

--- a/server/src/game/model/projectiles/Projectile.h
+++ b/server/src/game/model/projectiles/Projectile.h
@@ -24,7 +24,7 @@ public:
     std::unique_ptr<ProjectileBody> body;
     b2Body* B2Body();
 
-    void update(int it) override;
+    void update(int it, int rate) override;
     ProjectileDto to_dto() const;
     void explode();
     bool has_exploded() const;

--- a/server/src/game/model/projectiles/Projectile.h
+++ b/server/src/game/model/projectiles/Projectile.h
@@ -17,6 +17,8 @@ class Projectile: public Collidable, public Instance, Updatable {
     friend class InstancesManager;
     WeaponTypeDto weapon_type;
     bool exploded;
+    bool is_on_water;
+    int on_water_time_life;
     explicit Projectile(size_t id, const std::unique_ptr<ProjectileInfo> &info);
 public:
     float damage;

--- a/server/src/game/model/worm/Health.cpp
+++ b/server/src/game/model/worm/Health.cpp
@@ -22,3 +22,7 @@ void Health::receive_damage(float damage) {
         is_alive = false;
     }
 }
+
+void Health::die() {
+    actual_health = 0;
+}

--- a/server/src/game/model/worm/Health.h
+++ b/server/src/game/model/worm/Health.h
@@ -16,6 +16,8 @@ public:
     void receive_damage(float damage);
     void heal(float amount);
 
+    void die();
+
 };
 
 

--- a/server/src/game/model/worm/Worm.cpp
+++ b/server/src/game/model/worm/Worm.cpp
@@ -13,6 +13,8 @@ Worm::Worm(size_t id) :
     actual_weapon(weapons[WeaponTypeDto::BAZOOKA]),
     health(100),
     foot_sensor(this),
+    is_on_water(false),
+    water_death_timer(2000),
     body(nullptr),
     has_done_an_ending_turn_action(false)
     {}
@@ -61,10 +63,20 @@ WormFootSensor* Worm::get_foot_sensor() {
 }
 
 
-void Worm::update(const int it) {
+void Worm::update(const int it, const int rate) {
+    if (is_on_water) {
+        water_death_timer -= it * rate;
+        if (water_death_timer <= 0) {
+            // std::cout << "Worm id: " << id << "died\n";
+            health.die();
+            is_active = false;
+            return;
+        }
+    }
+
     health.on_update();
     if (!health.IsAlive()) {
-        std::cout << "Worm id: " << id << "died\n";
+        // std::cout << "Worm id: " << id << "died\n";
         is_active = false;
         return;
     }
@@ -113,7 +125,8 @@ void Worm::jump_backwards() const {
     body->jump_backwards();
 }
 
-void Worm::sink() const {
+void Worm::sink() {
+    is_on_water = true;
     body->sink();
 }
 
@@ -143,14 +156,14 @@ void Worm::stop_aiming_down() {
 }
 
 void Worm::start_shooting() {
-    if (actual_weapon) {
+    if (actual_weapon && !has_done_an_ending_turn_action) {
         // Logger::log_position("Worm shot", X(), Y());
         actual_weapon->start_shooting(X(),Y(),body->facing_direction_sign());
     }
 }
 
 void Worm::end_shooting() {
-    if (actual_weapon) {
+    if (actual_weapon && !has_done_an_ending_turn_action) {
         actual_weapon->end_shooting(X(),Y(),body->facing_direction_sign());
     }
 }

--- a/server/src/game/model/worm/Worm.h
+++ b/server/src/game/model/worm/Worm.h
@@ -25,7 +25,8 @@ private:
     std::shared_ptr<Weapon> & actual_weapon;
     Health health;
     WormFootSensor foot_sensor;
-
+    bool is_on_water;
+    int water_death_timer;
     explicit Worm(size_t id);
     WeaponMap create_default_weapons();
 
@@ -40,7 +41,7 @@ public:
     b2Body* B2Body() const;
     WormFootSensor* get_foot_sensor();
 
-    void update(int it) override;
+    void update(int it, const int rate) override;
     void on_turn_ended() override;
 
     // Movement
@@ -51,7 +52,7 @@ public:
     void stop_moving() const;
     void jump_forward() const;
     void jump_backwards() const;
-    void sink() const;
+    void sink();
 
     // Aim
     void start_aiming_up();

--- a/server/src/game/model/worm/WormBody.cpp
+++ b/server/src/game/model/worm/WormBody.cpp
@@ -94,13 +94,13 @@ void WormBody::on_update() {
     if (is_moving && is_on_ground) {
         body->SetLinearVelocity((b2Vec2(facing_direction_sign() * speed, y_velocity)));
     } else if(is_on_water) {
-        std::cout << "Worm sinking\n";
         BuoyancyForce force(world);
         force.apply(this->body);
     }
 
-
-    if (y_velocity > epsilon_y) {
+    if (is_on_water) {
+        state = State::SINKING;
+    } else if (y_velocity > epsilon_y) {
         state = State::JUMPING;
     } else if (y_velocity < -epsilon_y) {
         state = State::FALLING;

--- a/server/src/game/scenario/HardcodedScenarioData.h
+++ b/server/src/game/scenario/HardcodedScenarioData.h
@@ -9,7 +9,7 @@ public:
         GameScenarioData scenario;
         scenario.room_height = 40;
         scenario.room_width = 80;
-        scenario.water_height_level = 14;
+        scenario.water_height_level = 12;
         // Populate large beams next to each other at y=0
         float i = 0;
         scenario.beams.emplace_back(i++ * 6.0f + 23.0f, 13.0f, 00.0f, BeamScenarioData::Type::LONG);

--- a/server/src/game/systems/physics/PhysicsSystem.cpp
+++ b/server/src/game/systems/physics/PhysicsSystem.cpp
@@ -189,6 +189,6 @@ void PhysicsSystem::spawn_water(const GameScenarioData &scenario_data) {
     fixture_def.filter.maskBits = WORM_CATEGORY_BIT | PROJECTILE_CATEGORY_BIT;
     fixture_def.userData.pointer = reinterpret_cast<uintptr_t>(&water);
     fixture_def.isSensor = true;
-    auto fixture = water_body->CreateFixture(&fixture_def);
+    water_body->CreateFixture(&fixture_def);
 }
 

--- a/server/src/game/systems/physics/PhysicsSystem.cpp
+++ b/server/src/game/systems/physics/PhysicsSystem.cpp
@@ -15,7 +15,7 @@ PhysicsSystem::PhysicsSystem(
     water(),
     contactListener() {
     populate_beams(scenario);
-    // spawn_water(scenario);
+    spawn_water(scenario);
     world.SetContactListener(&contactListener);
 }
 
@@ -187,8 +187,8 @@ void PhysicsSystem::spawn_water(const GameScenarioData &scenario_data) {
     fixture_def.shape = &water_box;
     fixture_def.filter.categoryBits = WATER_CATEGORY_BIT;
     fixture_def.filter.maskBits = WORM_CATEGORY_BIT | PROJECTILE_CATEGORY_BIT;
-
+    fixture_def.userData.pointer = reinterpret_cast<uintptr_t>(&water);
     fixture_def.isSensor = true;
-    water_body->CreateFixture(&fixture_def);
+    auto fixture = water_body->CreateFixture(&fixture_def);
 }
 

--- a/server/src/game/systems/physics/PhysicsSystem.h
+++ b/server/src/game/systems/physics/PhysicsSystem.h
@@ -36,9 +36,6 @@ public:
     static const short WATER_CATEGORY_BIT = 16;
 
 private:
-    // Define category bits for fixtures
-
-
     const float timeStep;
     const int32 velocityIterations = 8;
     const int32 positionIterations = 3;

--- a/server/src/game/systems/turns/TurnSystem.h
+++ b/server/src/game/systems/turns/TurnSystem.h
@@ -34,7 +34,7 @@ class TurnSystem {
     bool worms_are_still(std::unordered_map<size_t, std::shared_ptr<Worm>>& worms);
 
 public:
-    TurnSystem(const int rate);
+    TurnSystem(int rate);
 
     int get_current_client_id() const;
     int get_current_worm_id() const;

--- a/server/src/game/systems/updatables/UpdatablesSystem.cpp
+++ b/server/src/game/systems/updatables/UpdatablesSystem.cpp
@@ -1,15 +1,18 @@
 #include "UpdatablesSystem.h"
 
+UpdatablesSystem::UpdatablesSystem(int rate): rate(rate)  {}
+
 void UpdatablesSystem::update(
     const int it,
     const std::unordered_map<size_t, std::shared_ptr<Worm>> &worms,
     const std::vector<std::shared_ptr<Projectile>> &projectiles
 ) {
     for (const auto& [_, worm]: worms) {
-        worm->update(it);
+        worm->update(it, rate);
     }
     for (const auto&  projectile: projectiles) {
-        projectile->update(it);
+        projectile->update(it, rate);
     }
 
 }
+

--- a/server/src/game/systems/updatables/UpdatablesSystem.h
+++ b/server/src/game/systems/updatables/UpdatablesSystem.h
@@ -6,8 +6,9 @@
 #include "../../core/InstancesManager.h"
 
 class UpdatablesSystem {
+    int rate;
 public:
-    UpdatablesSystem() = default;
+    UpdatablesSystem(int rate);
     void update(
         int it,
         const std::unordered_map<size_t, std::shared_ptr<Worm>> &worms,


### PR DESCRIPTION
Water on the server:
On collision with water projectiles and worms sink.
A Bouyance force is applied to them on every update
After 2 seconds in water worms die and its instance is destroyed.
Same for projectiles.

InitialNetMessage sended by network has now the water level height and the client when receiving it stores it on the game state dto.